### PR TITLE
feat : 이미지 드래그 업로드 기능

### DIFF
--- a/src/components/ImageUpload/index.tsx
+++ b/src/components/ImageUpload/index.tsx
@@ -1,6 +1,7 @@
 import $ from './style.module.scss';
 import Button from '@mui/material/Button';
 import { styled } from '@mui/material/styles';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 const Input = styled('input')({
   display: 'none',
@@ -9,21 +10,81 @@ const Input = styled('input')({
 interface Props {
   imageUrl?: string;
   setSelectedImage: React.Dispatch<React.SetStateAction<File | undefined>>;
+  setImageUrl: React.Dispatch<React.SetStateAction<string>>;
 }
 
-export default function ImageUpload({ imageUrl, setSelectedImage }: Props) {
+export default function ImageUpload({
+  imageUrl,
+  setSelectedImage,
+  setImageUrl,
+}: Props) {
+  const [isDragging, setIsDragging] = useState(false);
+  const dragRef = useRef<HTMLDivElement | null>(null);
+
   const selectImage = (e: React.ChangeEvent<HTMLInputElement>) => {
     const images = e.target.files;
-    if (!images) return;
-
-    if (images[0]) {
+    if (images?.[0]) {
       setSelectedImage(images[0]);
     }
   };
 
+  const eventPrevent = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const handleDragOut = useCallback((e: DragEvent): void => {
+    eventPrevent(e);
+    setIsDragging(false);
+  }, []);
+
+  const handleDragOver = useCallback((e: DragEvent): void => {
+    eventPrevent(e);
+    if (e.dataTransfer?.files) {
+      setIsDragging(true);
+    }
+  }, []);
+
+  const handleDrop = useCallback((e: DragEvent): void => {
+    eventPrevent(e);
+
+    if (e.type === 'drop') {
+      setImageUrl('');
+      setSelectedImage(e.dataTransfer?.files[0]);
+    }
+    setIsDragging(false);
+  }, []);
+
+  // 3개의 이벤트 Listener 등록 (마운트 될때)
+  const initDragEvents = useCallback(() => {
+    if (dragRef.current !== null) {
+      dragRef.current.addEventListener('dragleave', handleDragOut);
+      dragRef.current.addEventListener('dragover', handleDragOver);
+      dragRef.current.addEventListener('drop', handleDrop);
+    }
+  }, [handleDragOut, handleDragOver, handleDrop]);
+
+  // 3개의 이벤트 Listener 삭제 (언마운트 될때)
+  const resetDragEvents = useCallback(() => {
+    if (dragRef.current !== null) {
+      dragRef.current.removeEventListener('dragleave', handleDragOut);
+      dragRef.current.removeEventListener('dragover', handleDragOver);
+      dragRef.current.removeEventListener('drop', handleDrop);
+    }
+  }, [handleDragOut, handleDragOver, handleDrop]);
+
+  useEffect(() => {
+    initDragEvents();
+
+    return () => resetDragEvents();
+  }, [initDragEvents, resetDragEvents]);
+
   return (
     <div className={$['image-box']}>
-      <div className={$['sub-box']}>
+      <div
+        className={$[isDragging ? 'sub-box-dragging' : 'sub-box']}
+        ref={dragRef}
+      >
         <article>
           {!imageUrl ? (
             <>

--- a/src/components/ImageUpload/index.tsx
+++ b/src/components/ImageUpload/index.tsx
@@ -11,12 +11,14 @@ interface Props {
   imageUrl?: string;
   setSelectedImage: React.Dispatch<React.SetStateAction<File | undefined>>;
   setImageUrl: React.Dispatch<React.SetStateAction<string>>;
+  setSelectedGenre: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export default function ImageUpload({
   imageUrl,
   setSelectedImage,
   setImageUrl,
+  setSelectedGenre,
 }: Props) {
   const [isDragging, setIsDragging] = useState(false);
   const dragRef = useRef<HTMLDivElement | null>(null);
@@ -50,6 +52,7 @@ export default function ImageUpload({
 
     if (e.type === 'drop') {
       setImageUrl('');
+      setSelectedGenre('');
       setSelectedImage(e.dataTransfer?.files[0]);
     }
     setIsDragging(false);

--- a/src/components/ImageUpload/style.module.scss
+++ b/src/components/ImageUpload/style.module.scss
@@ -1,5 +1,43 @@
 @import 'src/styles/color.scss';
 
+@mixin ImageBox() {
+  border: 2px dashed $gray-2;
+  border-radius: 8px;
+  width: 100%;
+  height: 400px;
+  pointer-events: auto;
+  article {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    padding: 0 10px;
+    text-align: center;
+
+    strong {
+      font-weight: 400;
+      font-size: 25px;
+      margin: 0 8px;
+    }
+    span {
+      font-size: 15px;
+    }
+    label {
+      .image-upload-btn {
+        background-color: $primary-2;
+        color: $white;
+        border-radius: 20px;
+        margin-top: 40px;
+      }
+    }
+    img {
+      width: 90%;
+      height: 100%;
+    }
+  }
+}
+
 .image-box {
   display: flex;
   flex-direction: column;
@@ -14,41 +52,11 @@
   padding: 20px;
 
   .sub-box {
-    border: 2px dashed $gray-2;
-    border-radius: 8px;
-    width: 100%;
-    height: 400px;
-    pointer-events: auto;
+    @include ImageBox();
 
-    article {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      height: 100%;
-      padding: 0 10px;
-      text-align: center;
-
-      strong {
-        font-weight: 400;
-        font-size: 25px;
-        margin: 0 8px;
-      }
-      span {
-        font-size: 15px;
-      }
-      label {
-        .image-upload-btn {
-          background-color: $primary-2;
-          color: $white;
-          border-radius: 20px;
-          margin-top: 40px;
-        }
-      }
-      img {
-        width: 90%;
-        height: 100%;
-      }
+    &-dragging {
+      @include ImageBox();
+      border: 2px dashed $primary-1;
     }
   }
 }

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -84,7 +84,7 @@ export default function MainPage() {
           {showPopup && <Popup text={'플레이 리스트 생성 완료'} />}
         </div>
 
-        <div className={$['save-box']}>
+        <div className={$['save-modal-box']}>
           {showInputModal && (
             <>
               <Modal
@@ -95,7 +95,7 @@ export default function MainPage() {
             </>
           )}
 
-          {selectedImage && !selectedGenre && (
+          {selectedImage && !imageUrl && (
             <>
               <GenreModal setSelectedGenre={setSelectedGenre} />
               <ModalBack closeModal={() => setShowInputModal(false)} />
@@ -111,8 +111,10 @@ export default function MainPage() {
           <ImageUpload
             imageUrl={imageUrl}
             setSelectedImage={setSelectedImage}
+            setImageUrl={setImageUrl}
           />
         </section>
+
         {selectedGenre && (
           <section className={$['play-list-box']}>
             <div className={$['more-option']}>
@@ -137,6 +139,7 @@ export default function MainPage() {
           </section>
         )}
       </div>
+
       <section className={$['more-text']}>
         <TextBox
           title={firstText.title}

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -95,7 +95,7 @@ export default function MainPage() {
             </>
           )}
 
-          {selectedImage && !imageUrl && (
+          {selectedImage && !imageUrl && !selectedGenre && (
             <>
               <GenreModal setSelectedGenre={setSelectedGenre} />
               <ModalBack closeModal={() => setShowInputModal(false)} />
@@ -112,6 +112,7 @@ export default function MainPage() {
             imageUrl={imageUrl}
             setSelectedImage={setSelectedImage}
             setImageUrl={setImageUrl}
+            setSelectedGenre={setSelectedGenre}
           />
         </section>
 

--- a/src/pages/MainPage/style.module.scss
+++ b/src/pages/MainPage/style.module.scss
@@ -14,7 +14,7 @@
     right: 10px;
   }
 
-  .save-box {
+  .save-modal-box {
     position: absolute;
     z-index: 5;
   }


### PR DESCRIPTION
## 💡 이슈
resolve #18

## 📚 개요
이미지 드래그 업로드를 `addEventsListener`의 드래그 이벤트로 구현했습니다.
- 추가로, 이미 이미지로 업로드 한 후에도 다시 드래그를 할 경우 새로 업로드가 가능합니다.

## 👩🏻‍💻 작업사항
- `LoadedPlayList`
  - 이미지 드래그 이벤트 추가
  - 새로운 이미지가 드래그될 경우 -> 이전 이미지 url초기화, 이전 장르 초기화
  - 드래그 박스 안의 동일한 `article` 스타일을  `mixin`으로 생성

## 💫 추가 코멘트
- 그 외 추가적인 코멘트가 있을 경우 작성해주세요.
![화면 기록 2022-07-08 오후 7 55 37](https://user-images.githubusercontent.com/63364990/177979283-b8d57839-7145-466d-a52a-ac615f0ac85f.gif)

- 이벤트 함수라서 파라미터 전달때문에 파일 분리하기가 쉽지 않네요..